### PR TITLE
Improve the pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,3 +1,4 @@
+- [ ] The pull request is complete according to the Definition of Done
 - [ ] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
 - [ ] When applicable, the pull request title starts with the issue number
 - [ ] Automated tests have been written for this functionality

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,4 @@
-- [ ] The pull request title is descriptive about the change it introduces (keep in mind it will be used in the changelog)
+- [ ] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
 - [ ] When applicable, the pull request title starts with the issue number
 - [ ] This pull request targets the correct branch (**master** in case of a new feature, or the current release branch in case of a bugfix) and when merged results in a correct, working state of the system
 - [ ] Automated tests have been written for this functionality

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,5 @@
 - [ ] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
 - [ ] When applicable, the pull request title starts with the issue number
-- [ ] This pull request targets the correct branch (**master** in case of a new feature, or the current release branch in case of a bugfix) and when merged results in a correct, working state of the system
 - [ ] Automated tests have been written for this functionality
 - [ ] Functionality that cannot be tested automatically has been tested manually
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,5 @@
 - [ ] The pull request is complete according to the Definition of Done
+  - [ ] The pull request includes automated tests that prove the correctness of introduced changes
+  - [ ] Functionality that cannot be tested automatically has been tested manually
 - [ ] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
 - [ ] When applicable, the pull request title starts with the issue number
-- [ ] Automated tests have been written for this functionality
-- [ ] Functionality that cannot be tested automatically has been tested manually
-


### PR DESCRIPTION
GitHub has introduced a feature where an organization can have a `.github` repository containing some files (such as a pull request template) that is applied to all repositories in that organization - see https://github.blog/changelog/2019-02-21-organization-wide-community-health-files/.

I created this repository and in this pull request I want to propose some changes to our current pull request template.